### PR TITLE
Fix Dockerfile to copy built application and update port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ COPY package*.json ./
 # Install dependencies
 RUN npm install
 
+# Create the dist directory
+RUN mkdir -p /app/dist
+
 # Copy the rest of the application code
 COPY . .
 
@@ -29,7 +32,7 @@ COPY --from=build /app/dist ./dist
 RUN npm install -g serve
 
 # Expose the port the application will run on
-EXPOSE 5000
+EXPOSE 5173
 
 # Set the entry point to start the application
-CMD ["serve", "-s", "dist", "-l", "5000"]
+CMD ["serve", "-s", "dist", "-l", "5173"]

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -128,5 +128,5 @@ docker build -t keyyatri-password-manager .
 
 To run the Docker container for the application, use the following command:
 ```bash
-docker run -d -p 5000:5000 keyyatri-password-manager
+docker run -d -p 5173:5173 keyyatri-password-manager
 ```

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -95,7 +95,7 @@ Ensure the following configurations are set up correctly:
 
 To start the development server, run:
 ```bash
-npm run dev
+npm run dev -- --port 5173
 ```
 
 To build the project for production, run:


### PR DESCRIPTION
Update Dockerfile to create dist directory and expose port 5173

* Add a new line to create the `dist` directory before the `npm run build` command in the Dockerfile.
* Change the exposed port from 5000 to 5173 in the Dockerfile.
* Update the command to start the application to use port 5173 in the Dockerfile.

Update documentation to reflect port change

* Update the command to start the development server to run on port 5173 in `docs/Setup.md`.
* Update the command to start the Docker container to run on port 5173 in `docs/Docker.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yatricloud/keyyatri-live/pull/12?shareId=6d4fe0c0-464d-4c25-a167-3aee4842f568).